### PR TITLE
Restrict access to admin pages

### DIFF
--- a/frontend/src/pages/AddEditUserPage.js
+++ b/frontend/src/pages/AddEditUserPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
@@ -7,6 +7,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import Navbar from '../components/Navbar';
 import Sidebar from '../components/Sidebar';
+import { UserContext } from '../contexts/UserContext';
 import { getUserById, adminUpdateUser } from '../api/authApi';
 
 // Page for adding or editing a user.  If an id param is present, the form
@@ -15,8 +16,18 @@ import { getUserById, adminUpdateUser } from '../api/authApi';
 export default function AddEditUserPage() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const { currentUser } = useContext(UserContext);
   const isEdit = Boolean(id);
   const [formData, setFormData] = useState({ username: '', email: '', role: 'student', status: 'active' });
+
+  if (!currentUser?.is_admin) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6">Access Denied</Typography>
+        <Typography>You must be an admin to view this page.</Typography>
+      </Box>
+    );
+  }
 
   useEffect(() => {
     // Fetch user details if editing

--- a/frontend/src/pages/BulkUserUploadPage.js
+++ b/frontend/src/pages/BulkUserUploadPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
@@ -11,12 +11,23 @@ import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
 import Navbar from '../components/Navbar';
 import Sidebar from '../components/Sidebar';
+import { UserContext } from '../contexts/UserContext';
 
 // Page allowing admins to select a CSV file, preview its contents and
 // submit it for upload.  For now the Upload button does not send the
 // data anywhere.
 export default function BulkUserUploadPage() {
   const [rows, setRows] = useState([]);
+  const { currentUser } = useContext(UserContext);
+
+  if (!currentUser?.is_admin) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6">Access Denied</Typography>
+        <Typography>You must be an admin to view this page.</Typography>
+      </Box>
+    );
+  }
 
   const handleFileChange = (e) => {
     const file = e.target.files[0];

--- a/frontend/src/pages/UserList.js
+++ b/frontend/src/pages/UserList.js
@@ -22,6 +22,15 @@ export default function UserList() {
   const { currentUser } = useContext(UserContext);
   const [users, setUsers] = useState([]);
 
+  if (!currentUser?.is_admin) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6">Access Denied</Typography>
+        <Typography>You must be an admin to view this page.</Typography>
+      </Box>
+    );
+  }
+
   useEffect(() => {
     // Fetch all users if current user is admin
     const fetchUsers = async () => {


### PR DESCRIPTION
## Summary
- protect admin pages from regular users
- show an Access Denied message when non-admins hit admin routes

## Testing
- `CI=true node node_modules/react-scripts/bin/react-scripts.js test --silent`
- `python auth_service/test_db_connection.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6884468706148330938bc5e09e626fd7